### PR TITLE
Add NewsRoot umbrella skeleton

### DIFF
--- a/.formatter.exs
+++ b/.formatter.exs
@@ -1,0 +1,6 @@
+[
+  import_deps: [],
+  inputs: ["{mix,.formatter}.exs", "{config,apps}/**/*.{ex,exs}"],
+  subdirectories: ["apps/*"],
+  umbrella: true
+]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,14 @@
+name: CI
+on: [push, pull_request]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: erlef/setup-beam@v1
+        with:
+          elixir-version: '1.17'
+          otp-version: '26'
+      - run: mix deps.get
+      - run: mix format --check-formatted
+      - run: mix test

--- a/README.md
+++ b/README.md
@@ -1,1 +1,3 @@
-# newsroot
+# NewsRoot
+
+Run `mix setup` to fetch dependencies and set up the database.

--- a/apps/newsroot_ai/lib/newsroot_ai/application.ex
+++ b/apps/newsroot_ai/lib/newsroot_ai/application.ex
@@ -1,0 +1,11 @@
+defmodule NewsrootAI.Application do
+  use Application
+
+  def start(_type, _args) do
+    children = [
+      {Oban, Application.fetch_env!(:newsroot_ai, Oban)}
+    ]
+
+    Supervisor.start_link(children, strategy: :one_for_one, name: __MODULE__)
+  end
+end

--- a/apps/newsroot_ai/lib/newsroot_ai/pipeline/base_pipeline.ex
+++ b/apps/newsroot_ai/lib/newsroot_ai/pipeline/base_pipeline.ex
@@ -1,0 +1,3 @@
+defmodule NewsrootAI.Pipeline.BasePipeline do
+  @moduledoc false
+end

--- a/apps/newsroot_ai/lib/newsroot_ai/worker/analysis_worker.ex
+++ b/apps/newsroot_ai/lib/newsroot_ai/worker/analysis_worker.ex
@@ -1,0 +1,8 @@
+defmodule NewsrootAI.Worker.AnalysisWorker do
+  use Oban.Worker, queue: :analysis, max_attempts: 5
+
+  @impl Oban.Worker
+  def perform(_job) do
+    :ok
+  end
+end

--- a/apps/newsroot_ai/mix.exs
+++ b/apps/newsroot_ai/mix.exs
@@ -1,0 +1,32 @@
+defmodule NewsrootAI.MixProject do
+  use Mix.Project
+
+  def project do
+    [
+      app: :newsroot_ai,
+      version: "0.1.0",
+      build_path: "../../_build",
+      config_path: "../../config/config.exs",
+      deps_path: "../../deps",
+      lockfile: "../../mix.lock",
+      elixir: "~> 1.17",
+      start_permanent: Mix.env() == :prod,
+      deps: deps()
+    ]
+  end
+
+  def application do
+    [
+      mod: {NewsrootAI.Application, []},
+      extra_applications: [:logger]
+    ]
+  end
+
+  defp deps do
+    [
+      {:ash, "~> 2.19"},
+      {:oban, "~> 2.17"},
+      {:openai_ex, "~> 0.4"}
+    ]
+  end
+end

--- a/apps/newsroot_core/lib/newsroot_core/application.ex
+++ b/apps/newsroot_core/lib/newsroot_core/application.ex
@@ -1,0 +1,11 @@
+defmodule NewsrootCore.Application do
+  use Application
+
+  def start(_type, _args) do
+    children = [
+      NewsrootCore.Repo
+    ]
+
+    Supervisor.start_link(children, strategy: :one_for_one, name: __MODULE__)
+  end
+end

--- a/apps/newsroot_core/lib/newsroot_core/article.ex
+++ b/apps/newsroot_core/lib/newsroot_core/article.ex
@@ -1,0 +1,15 @@
+defmodule NewsrootCore.Article do
+  use Ash.Resource,
+    data_layer: AshPostgres.DataLayer
+
+  postgres do
+    table "articles"
+    repo NewsrootCore.Repo
+  end
+
+  attributes do
+    uuid_primary_key :id
+    attribute :title, :string
+    attribute :body_path, :string
+  end
+end

--- a/apps/newsroot_core/lib/newsroot_core/repo.ex
+++ b/apps/newsroot_core/lib/newsroot_core/repo.ex
@@ -1,0 +1,3 @@
+defmodule NewsrootCore.Repo do
+  use AshPostgres.Repo, otp_app: :newsroot_core
+end

--- a/apps/newsroot_core/lib/newsroot_core/topic_edge.ex
+++ b/apps/newsroot_core/lib/newsroot_core/topic_edge.ex
@@ -1,0 +1,15 @@
+defmodule NewsrootCore.TopicEdge do
+  use Ash.Resource,
+    data_layer: AshPostgres.DataLayer
+
+  postgres do
+    table "topic_edges"
+    repo NewsrootCore.Repo
+  end
+
+  attributes do
+    uuid_primary_key :id
+    attribute :from_id, :uuid
+    attribute :to_id, :uuid
+  end
+end

--- a/apps/newsroot_core/mix.exs
+++ b/apps/newsroot_core/mix.exs
@@ -1,0 +1,32 @@
+defmodule NewsrootCore.MixProject do
+  use Mix.Project
+
+  def project do
+    [
+      app: :newsroot_core,
+      version: "0.1.0",
+      build_path: "../../_build",
+      config_path: "../../config/config.exs",
+      deps_path: "../../deps",
+      lockfile: "../../mix.lock",
+      elixir: "~> 1.17",
+      start_permanent: Mix.env() == :prod,
+      deps: deps()
+    ]
+  end
+
+  def application do
+    [
+      mod: {NewsrootCore.Application, []},
+      extra_applications: [:logger, :runtime_tools]
+    ]
+  end
+
+  defp deps do
+    [
+      {:ash, "~> 2.19"},
+      {:ash_postgres, "~> 1.2"},
+      {:oban, "~> 2.17"}
+    ]
+  end
+end

--- a/apps/newsroot_fetcher/config/oban.exs
+++ b/apps/newsroot_fetcher/config/oban.exs
@@ -1,0 +1,6 @@
+import Config
+
+config :newsroot_fetcher, Oban,
+  repo: NewsrootCore.Repo,
+  queues: [rss: 10, html: 10],
+  plugins: [{Oban.Plugins.Cron, crontab: [{"*/5 * * * *", NewsrootFetcher.Worker.RSSWorker}]}]

--- a/apps/newsroot_fetcher/lib/newsroot_fetcher/application.ex
+++ b/apps/newsroot_fetcher/lib/newsroot_fetcher/application.ex
@@ -1,0 +1,11 @@
+defmodule NewsrootFetcher.Application do
+  use Application
+
+  def start(_type, _args) do
+    children = [
+      {Oban, Application.fetch_env!(:newsroot_fetcher, Oban)}
+    ]
+
+    Supervisor.start_link(children, strategy: :one_for_one, name: __MODULE__)
+  end
+end

--- a/apps/newsroot_fetcher/lib/newsroot_fetcher/worker/html_worker.ex
+++ b/apps/newsroot_fetcher/lib/newsroot_fetcher/worker/html_worker.ex
@@ -1,0 +1,8 @@
+defmodule NewsrootFetcher.Worker.HTMLWorker do
+  use Oban.Worker, queue: :html, max_attempts: 5
+
+  @impl Oban.Worker
+  def perform(_job) do
+    :ok
+  end
+end

--- a/apps/newsroot_fetcher/lib/newsroot_fetcher/worker/rss_worker.ex
+++ b/apps/newsroot_fetcher/lib/newsroot_fetcher/worker/rss_worker.ex
@@ -1,0 +1,8 @@
+defmodule NewsrootFetcher.Worker.RSSWorker do
+  use Oban.Worker, queue: :rss, max_attempts: 5
+
+  @impl Oban.Worker
+  def perform(_job) do
+    :ok
+  end
+end

--- a/apps/newsroot_fetcher/mix.exs
+++ b/apps/newsroot_fetcher/mix.exs
@@ -1,0 +1,33 @@
+defmodule NewsrootFetcher.MixProject do
+  use Mix.Project
+
+  def project do
+    [
+      app: :newsroot_fetcher,
+      version: "0.1.0",
+      build_path: "../../_build",
+      config_path: "../../config/config.exs",
+      deps_path: "../../deps",
+      lockfile: "../../mix.lock",
+      elixir: "~> 1.17",
+      start_permanent: Mix.env() == :prod,
+      deps: deps()
+    ]
+  end
+
+  def application do
+    [
+      mod: {NewsrootFetcher.Application, []},
+      extra_applications: [:logger]
+    ]
+  end
+
+  defp deps do
+    [
+      {:ash, "~> 2.19"},
+      {:oban, "~> 2.17"},
+      {:req, "~> 0.4"},
+      {:finch, "~> 0.16"}
+    ]
+  end
+end

--- a/apps/newsroot_web/config/runtime.exs
+++ b/apps/newsroot_web/config/runtime.exs
@@ -1,0 +1,5 @@
+import Config
+
+config :newsroot_web, NewsrootWeb.Endpoint,
+  http: [port: String.to_integer(System.get_env("PORT") || "4000")],
+  url: [host: System.get_env("HOST") || "localhost", port: 4000]

--- a/apps/newsroot_web/lib/newsroot_web/application.ex
+++ b/apps/newsroot_web/lib/newsroot_web/application.ex
@@ -1,0 +1,11 @@
+defmodule NewsrootWeb.Application do
+  use Application
+
+  def start(_type, _args) do
+    children = [
+      {Plug.Cowboy, scheme: :http, plug: NewsrootWeb.Router, options: [port: 4000]}
+    ]
+
+    Supervisor.start_link(children, strategy: :one_for_one, name: __MODULE__)
+  end
+end

--- a/apps/newsroot_web/lib/newsroot_web/router.ex
+++ b/apps/newsroot_web/lib/newsroot_web/router.ex
@@ -1,0 +1,21 @@
+defmodule NewsrootWeb.Router do
+  use Plug.Router
+
+  plug Plug.Static,
+    at: "/",
+    from: {:newsroot_web, "priv/assets"},
+    only: ~w(index.html main.js sw.js manifest.json offline.html)
+
+  plug :match
+  plug :dispatch
+
+  get "/" do
+    conn |> Plug.Conn.send_file(200, asset("index.html"))
+  end
+
+  match _ do
+    send_resp(conn, 404, "Not found")
+  end
+
+  defp asset(file), do: Path.join(:code.priv_dir(:newsroot_web), "assets/" <> file)
+end

--- a/apps/newsroot_web/mix.exs
+++ b/apps/newsroot_web/mix.exs
@@ -1,0 +1,31 @@
+defmodule NewsrootWeb.MixProject do
+  use Mix.Project
+
+  def project do
+    [
+      app: :newsroot_web,
+      version: "0.1.0",
+      build_path: "../../_build",
+      config_path: "../../config/config.exs",
+      deps_path: "../../deps",
+      lockfile: "../../mix.lock",
+      elixir: "~> 1.17",
+      start_permanent: Mix.env() == :prod,
+      deps: deps()
+    ]
+  end
+
+  def application do
+    [
+      mod: {NewsrootWeb.Application, []},
+      extra_applications: [:logger, :runtime_tools]
+    ]
+  end
+
+  defp deps do
+    [
+      {:plug_cowboy, "~> 2.6"},
+      {:jason, "~> 1.4"}
+    ]
+  end
+end

--- a/apps/newsroot_web/priv/assets/index.html
+++ b/apps/newsroot_web/priv/assets/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8" />
+  <link rel="manifest" href="/manifest.json" />
+</head>
+<body>
+  <h1>NewsRoot</h1>
+  <script src="/main.js"></script>
+</body>
+</html>

--- a/apps/newsroot_web/priv/assets/main.js
+++ b/apps/newsroot_web/priv/assets/main.js
@@ -1,0 +1,3 @@
+fetch('/some/api')
+  .then(r => r.text())
+  .then(html => document.body.insertAdjacentHTML('beforeend', html));

--- a/apps/newsroot_web/priv/assets/manifest.json
+++ b/apps/newsroot_web/priv/assets/manifest.json
@@ -1,0 +1,6 @@
+{
+  "name": "NewsRoot",
+  "short_name": "NewsRoot",
+  "start_url": "/",
+  "display": "standalone"
+}

--- a/apps/newsroot_web/priv/assets/offline.html
+++ b/apps/newsroot_web/priv/assets/offline.html
@@ -1,0 +1,6 @@
+<!DOCTYPE html>
+<html>
+<body>
+  <p>You are offline.</p>
+</body>
+</html>

--- a/apps/newsroot_web/priv/assets/sw.js
+++ b/apps/newsroot_web/priv/assets/sw.js
@@ -1,0 +1,11 @@
+self.addEventListener('install', (e) => {
+  e.waitUntil(
+    caches.open('v1').then((cache) => cache.addAll(['/offline.html']))
+  );
+});
+
+self.addEventListener('fetch', (e) => {
+  e.respondWith(
+    fetch(e.request).catch(() => caches.match('/offline.html'))
+  );
+});

--- a/config/config.exs
+++ b/config/config.exs
@@ -1,0 +1,15 @@
+import Config
+
+config :newsroot_core, ecto_repos: [NewsrootCore.Repo]
+
+config :newsroot_core, NewsrootCore.Repo,
+  database: System.get_env("DB_NAME") || "newsroot_dev",
+  username: System.get_env("DB_USER") || "postgres",
+  password: System.get_env("DB_PASS") || "postgres",
+  hostname: System.get_env("DB_HOST") || "localhost"
+
+config :newsroot_fetcher, Oban,
+  repo: NewsrootCore.Repo,
+  queues: [rss: 10, html: 10]
+
+config :logger, level: :info

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -1,0 +1,5 @@
+import Config
+
+config :newsroot_web, NewsrootWeb.Endpoint,
+  http: [port: 4000],
+  url: [host: "localhost"]

--- a/config/prod.exs
+++ b/config/prod.exs
@@ -1,0 +1,5 @@
+import Config
+
+config :newsroot_web, NewsrootWeb.Endpoint,
+  http: [port: String.to_integer(System.get_env("PORT") || "4000")],
+  url: [host: System.get_env("HOST") || "example.com", port: 80]

--- a/config/test.exs
+++ b/config/test.exs
@@ -1,0 +1,2 @@
+import Config
+config :logger, level: :warning

--- a/mix.exs
+++ b/mix.exs
@@ -1,0 +1,32 @@
+defmodule Newsroot.MixProject do
+  use Mix.Project
+
+  def project do
+    [
+      apps_path: "apps",
+      version: "0.1.0",
+      elixir: "~> 1.17",
+      start_permanent: Mix.env() == :prod,
+      deps: deps(),
+      aliases: aliases()
+    ]
+  end
+
+  defp deps do
+    [
+      {:oban, "~> 2.17"},
+      {:ash, "~> 2.19"},
+      {:ash_postgres, "~> 1.2"},
+      {:jason, "~> 1.4"},
+      {:nimble_csv, "~> 1.2"},
+      {:req, "~> 0.4"},
+      {:finch, "~> 0.16"}
+    ]
+  end
+
+  defp aliases do
+    [
+      setup: ["deps.get", "ecto.setup", "cmd npm install --prefix apps/newsroot_web/assets"]
+    ]
+  end
+end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,0 +1,1 @@
+ExUnit.start()


### PR DESCRIPTION
## Summary
- set up umbrella project structure for NewsRoot
- add placeholder mix files, applications, and workers
- add basic Plug PWA host and static assets
- provide configuration and CI workflow
- remove redundant README description

------
https://chatgpt.com/codex/tasks/task_e_68693f93c910833291343ad17134e162